### PR TITLE
feat: add 90-day document retention with synchronized S3 cleanup

### DIFF
--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -6,6 +6,7 @@ import { resumeGenerationFunction } from '@/inngest/functions/resume-generation'
 import { coverLetterGenerationFunction } from '@/inngest/functions/cover-letter-generation'
 import { companyResearchFunction } from '@/inngest/functions/company-research'
 import { runSavedSearches } from '@/inngest/functions/run-saved-searches'
+import { documentCleanupFunction } from '@/inngest/functions/document-cleanup'
 
 export const { GET, POST, PUT } = serve({
   client: inngest,
@@ -16,5 +17,6 @@ export const { GET, POST, PUT } = serve({
     coverLetterGenerationFunction,
     companyResearchFunction,
     runSavedSearches,
+    documentCleanupFunction,
   ],
 })

--- a/inngest/functions/document-cleanup.ts
+++ b/inngest/functions/document-cleanup.ts
@@ -1,0 +1,63 @@
+import { inngest } from '@/lib/inngest'
+import { prisma } from '@/lib/prisma'
+import { permanentlyDeleteDocument } from '@/lib/actions/delete-document'
+
+const RETENTION_DAYS = 90
+
+/**
+ * Scheduled job to clean up expired generated documents.
+ *
+ * Schedule: Daily at 2:00 AM UTC
+ * - Finds documents older than 90 days
+ * - Deletes S3 objects and DB records for each
+ * - Uses per-document steps for Inngest idempotency
+ */
+export const documentCleanupFunction = inngest.createFunction(
+  {
+    id: 'document-cleanup',
+    name: 'Document Cleanup',
+  },
+  { cron: '0 2 * * *' }, // Daily at 2:00 AM UTC
+  async ({ step, logger }) => {
+    const expiredDocuments = await step.run('find-expired-documents', async () => {
+      const cutoffDate = new Date()
+      cutoffDate.setDate(cutoffDate.getDate() - RETENTION_DAYS)
+
+      return await prisma.generatedDocument.findMany({
+        where: { created_at: { lt: cutoffDate } },
+        select: { id: true, storage_url: true, application_id: true, type: true },
+      })
+    })
+
+    logger.info(`Found ${expiredDocuments.length} expired documents to clean up`)
+
+    if (expiredDocuments.length === 0) {
+      return { message: 'No expired documents found', documentsDeleted: 0, documentsFailed: 0 }
+    }
+
+    let documentsDeleted = 0
+    let documentsFailed = 0
+    const errors: string[] = []
+
+    for (const doc of expiredDocuments) {
+      const result = await step.run(`delete-doc-${doc.id}`, async () => {
+        return await permanentlyDeleteDocument(doc.id)
+      })
+
+      if (result.success) {
+        documentsDeleted++
+      } else {
+        documentsFailed++
+        errors.push(`${doc.id}: ${result.error}`)
+        logger.error(`Failed to delete document ${doc.id}: ${result.error}`)
+      }
+    }
+
+    return {
+      message: 'Document cleanup completed',
+      documentsDeleted,
+      documentsFailed,
+      errors,
+    }
+  }
+)

--- a/lib/actions/__tests__/delete-document.test.ts
+++ b/lib/actions/__tests__/delete-document.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// vi.hoisted runs before imports, so inline the mock creation
+const { mockGeneratedDocument, mockDeleteFile } = vi.hoisted(() => {
+  return {
+    mockGeneratedDocument: {
+      findUnique: vi.fn(),
+      delete: vi.fn(),
+    },
+    mockDeleteFile: vi.fn(),
+  }
+})
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { generatedDocument: mockGeneratedDocument },
+}))
+
+vi.mock('@/lib/s3', () => ({ deleteFile: mockDeleteFile }))
+
+import { permanentlyDeleteDocument } from '../delete-document'
+
+describe('permanentlyDeleteDocument', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns error when document does not exist', async () => {
+    mockGeneratedDocument.findUnique.mockResolvedValue(null)
+
+    const result = await permanentlyDeleteDocument('nonexistent-id')
+
+    expect(result).toEqual({ success: false, error: 'Document not found' })
+    expect(mockDeleteFile).not.toHaveBeenCalled()
+    expect(mockGeneratedDocument.delete).not.toHaveBeenCalled()
+  })
+
+  it('does not delete DB record when S3 deletion fails', async () => {
+    mockGeneratedDocument.findUnique.mockResolvedValue({
+      id: 'doc-1',
+      storage_url: 'documents/app-1/resume-123.pdf',
+    })
+    mockDeleteFile.mockRejectedValue(new Error('S3 access denied'))
+
+    const result = await permanentlyDeleteDocument('doc-1')
+
+    expect(result).toEqual({
+      success: false,
+      error: 'S3 deletion failed: S3 access denied',
+    })
+    expect(mockDeleteFile).toHaveBeenCalledWith('documents/app-1/resume-123.pdf')
+    expect(mockGeneratedDocument.delete).not.toHaveBeenCalled()
+  })
+
+  it('deletes S3 object and DB record on success', async () => {
+    mockGeneratedDocument.findUnique.mockResolvedValue({
+      id: 'doc-1',
+      storage_url: 'documents/app-1/resume-123.pdf',
+    })
+    mockDeleteFile.mockResolvedValue(undefined)
+    mockGeneratedDocument.delete.mockResolvedValue({})
+
+    const result = await permanentlyDeleteDocument('doc-1')
+
+    expect(result).toEqual({
+      success: true,
+      data: { id: 'doc-1', storage_url: 'documents/app-1/resume-123.pdf' },
+    })
+    expect(mockDeleteFile).toHaveBeenCalledWith('documents/app-1/resume-123.pdf')
+    expect(mockGeneratedDocument.delete).toHaveBeenCalledWith({
+      where: { id: 'doc-1' },
+    })
+  })
+
+  it('returns error when DB deletion fails after S3 succeeds', async () => {
+    mockGeneratedDocument.findUnique.mockResolvedValue({
+      id: 'doc-1',
+      storage_url: 'documents/app-1/resume-123.pdf',
+    })
+    mockDeleteFile.mockResolvedValue(undefined)
+    mockGeneratedDocument.delete.mockRejectedValue(new Error('DB constraint violation'))
+
+    const result = await permanentlyDeleteDocument('doc-1')
+
+    expect(result).toEqual({
+      success: false,
+      error: 'DB deletion failed after S3 delete: DB constraint violation',
+    })
+    expect(mockDeleteFile).toHaveBeenCalledWith('documents/app-1/resume-123.pdf')
+    expect(mockGeneratedDocument.delete).toHaveBeenCalled()
+  })
+})

--- a/lib/actions/delete-document.ts
+++ b/lib/actions/delete-document.ts
@@ -1,0 +1,45 @@
+import { prisma } from '@/lib/prisma'
+import { deleteFile } from '@/lib/s3'
+
+type DeleteResult =
+  | { success: true; data: { id: string; storage_url: string } }
+  | { success: false; error: string }
+
+/**
+ * Permanently delete a generated document from S3 and the database.
+ * S3 deletion happens first - if it fails, the DB record is preserved.
+ */
+export async function permanentlyDeleteDocument(documentId: string): Promise<DeleteResult> {
+  const document = await prisma.generatedDocument.findUnique({
+    where: { id: documentId },
+    select: { id: true, storage_url: true },
+  })
+
+  if (!document) {
+    return { success: false, error: 'Document not found' }
+  }
+
+  // Delete from S3 first - if this fails, we keep the DB record
+  try {
+    await deleteFile(document.storage_url)
+  } catch (error) {
+    return {
+      success: false,
+      error: `S3 deletion failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    }
+  }
+
+  // S3 succeeded - now delete DB record
+  try {
+    await prisma.generatedDocument.delete({
+      where: { id: documentId },
+    })
+  } catch (error) {
+    return {
+      success: false,
+      error: `DB deletion failed after S3 delete: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    }
+  }
+
+  return { success: true, data: { id: document.id, storage_url: document.storage_url } }
+}


### PR DESCRIPTION
## Summary

- Add a daily Inngest cron job (2:00 AM UTC) that permanently deletes generated documents (resumes, cover letters) older than 90 days from both S3 and the database
- Wire up the existing `deleteFile()` function in `lib/s3.ts` which was never called
- S3 deletion happens before DB deletion to prevent orphaned S3 objects - if S3 fails, the DB record is preserved
- Per-document Inngest steps provide idempotent crash recovery (resumes from last completed deletion if the function fails mid-batch)

## Changes

| File | Change |
|------|--------|
| `lib/actions/delete-document.ts` | Core deletion logic with discriminated union return type |
| `inngest/functions/document-cleanup.ts` | Scheduled cron function following `runSavedSearches` pattern |
| `app/api/inngest/route.ts` | Register new function in Inngest serve config |
| `lib/actions/__tests__/delete-document.test.ts` | 4 unit tests covering all error paths |

## Test plan

- [x] `npm test -- lib/actions/__tests__/delete-document.test.ts` - all 4 tests pass
- [x] `npm test` - full suite (186 tests) passes with no regressions
- [x] `npm run lint` - clean
- [x] Deploy to staging and verify the cron job appears in Inngest dashboard
- [x] Manually trigger the function in Inngest dev server to confirm it finds/deletes expired documents