### PR TITLE
fix: improve mobile UI across multiple views

### DIFF
--- a/components/dashboard/pipeline.tsx
+++ b/components/dashboard/pipeline.tsx
@@ -12,7 +12,8 @@ import {
   useDroppable,
 } from '@dnd-kit/core'
 import { ApplicationCard } from './application-card'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { ChevronRight } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 
@@ -218,36 +219,38 @@ export function Pipeline({ applications, searchQuery, fitFilter, statusFilter }:
         </DndContext>
       </div>
 
-      {/* Mobile View - Tabs */}
-      <div className="lg:hidden">
-        <Tabs defaultValue={ApplicationStatus.PLANNED} className="w-full">
-          <TabsList className="grid w-full grid-cols-5 mb-6">
-            {STATUS_COLUMNS.map(({ status, label }) => (
-              <TabsTrigger key={status} value={status} className="text-xs">
-                {label}
-                <span className="ml-1 text-secondary/50">
-                  ({applicationsByStatus[status].length})
-                </span>
-              </TabsTrigger>
-            ))}
-          </TabsList>
+      {/* Mobile View - Accordion Sections */}
+      <div className="lg:hidden space-y-2">
+        {STATUS_COLUMNS.map(({ status, label, color }) => {
+          const columnApps = applicationsByStatus[status]
+          const hasItems = columnApps.length > 0
+          const isFirstWithItems =
+            hasItems &&
+            STATUS_COLUMNS.findIndex(col => applicationsByStatus[col.status].length > 0) ===
+              STATUS_COLUMNS.findIndex(col => col.status === status)
 
-          {STATUS_COLUMNS.map(({ status }) => {
-            const columnApps = applicationsByStatus[status]
-
-            return (
-              <TabsContent key={status} value={status} className="space-y-3">
-                {columnApps.length === 0 ? (
-                  <div className="text-center py-12 text-sm text-secondary/50">
-                    No applications in {status.toLowerCase()}
-                  </div>
-                ) : (
-                  columnApps.map(app => <ApplicationCard key={app.id} application={app} />)
-                )}
-              </TabsContent>
-            )
-          })}
-        </Tabs>
+          return (
+            <Collapsible key={status} defaultOpen={isFirstWithItems}>
+              <CollapsibleTrigger className="flex items-center gap-3 w-full p-3 rounded-xl hover:bg-primary/30 transition-colors group">
+                <ChevronRight className="h-4 w-4 text-secondary/60 transition-transform group-data-[state=open]:rotate-90" />
+                <div className={`h-5 w-1 rounded-full bg-${color}`} />
+                <span className="font-semibold text-secondary">{label}</span>
+                <span className="text-sm text-secondary/50 ml-auto">{columnApps.length}</span>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className="space-y-3 pt-2 pb-1">
+                  {columnApps.length === 0 ? (
+                    <div className="text-center py-6 text-sm text-secondary/50">
+                      No applications
+                    </div>
+                  ) : (
+                    columnApps.map(app => <ApplicationCard key={app.id} application={app} />)
+                  )}
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          )
+        })}
       </div>
     </>
   )

--- a/components/forms/skills-input.tsx
+++ b/components/forms/skills-input.tsx
@@ -12,17 +12,18 @@ interface SkillsInputProps {
   className?: string
 }
 
+const COLLAPSED_COUNT = 10
+
 export function SkillsInput({ value, onChange, className }: SkillsInputProps) {
   const [inputValue, setInputValue] = useState('')
+  const [expanded, setExpanded] = useState(false)
 
   const handleAdd = () => {
     const trimmed = inputValue.trim()
     if (!trimmed) return
 
     // Check for duplicates (case-insensitive)
-    const isDuplicate = value.some(
-      (skill) => skill.toLowerCase() === trimmed.toLowerCase()
-    )
+    const isDuplicate = value.some(skill => skill.toLowerCase() === trimmed.toLowerCase())
 
     if (!isDuplicate) {
       onChange([...value, trimmed])
@@ -31,7 +32,7 @@ export function SkillsInput({ value, onChange, className }: SkillsInputProps) {
   }
 
   const handleRemove = (skill: string) => {
-    onChange(value.filter((s) => s !== skill))
+    onChange(value.filter(s => s !== skill))
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -48,39 +49,48 @@ export function SkillsInput({ value, onChange, className }: SkillsInputProps) {
         <Input
           type="text"
           value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
+          onChange={e => setInputValue(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="e.g., React, TypeScript, Python"
           className="flex-1"
         />
-        <Button
-          type="button"
-          onClick={handleAdd}
-          disabled={!inputValue.trim()}
-          size="icon"
-        >
+        <Button type="button" onClick={handleAdd} disabled={!inputValue.trim()} size="icon">
           <Plus className="h-4 w-4" />
         </Button>
       </div>
 
       {/* Skills chips */}
       {value.length > 0 && (
-        <div className="flex flex-wrap gap-2">
-          {value.map((skill) => (
-            <div
-              key={skill}
-              className="inline-flex items-center gap-1 bg-primary text-secondary px-3 py-1.5 rounded-full text-sm font-medium"
-            >
-              {skill}
-              <button
-                type="button"
-                onClick={() => handleRemove(skill)}
-                className="ml-1 hover:bg-gray-200 rounded-full p-0.5 transition-colors"
+        <div>
+          <div className="flex flex-wrap gap-2">
+            {(expanded || value.length <= COLLAPSED_COUNT
+              ? value
+              : value.slice(0, COLLAPSED_COUNT)
+            ).map(skill => (
+              <div
+                key={skill}
+                className="inline-flex items-center gap-1 bg-primary text-secondary px-3 py-1.5 rounded-full text-sm font-medium"
               >
-                <X className="h-3 w-3" />
-              </button>
-            </div>
-          ))}
+                {skill}
+                <button
+                  type="button"
+                  onClick={() => handleRemove(skill)}
+                  className="ml-1 hover:bg-gray-200 rounded-full p-0.5 transition-colors"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </div>
+            ))}
+          </div>
+          {value.length > COLLAPSED_COUNT && (
+            <button
+              type="button"
+              onClick={() => setExpanded(!expanded)}
+              className="text-sm text-accent-teal hover:text-accent-teal/80 cursor-pointer mt-2"
+            >
+              {expanded ? 'Show less' : `Show all (${value.length})`}
+            </button>
+          )}
         </div>
       )}
 

--- a/components/jobs/documents-list.tsx
+++ b/components/jobs/documents-list.tsx
@@ -212,14 +212,15 @@ export function DocumentsList({ documents, applicationId, documentTasks }: Docum
 
   return (
     <div className="bg-white rounded-2xl border border-secondary/10 shadow-card p-8">
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
         <h2 className="font-lora text-2xl font-semibold text-secondary">Documents</h2>
-        <div className="flex gap-3">
+        <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
           <Button
             onClick={handleGenerateResume}
             disabled={isGeneratingResume}
             variant="default"
             size="sm"
+            className="w-full sm:w-auto"
           >
             {isGeneratingResume ? (
               <>
@@ -238,6 +239,7 @@ export function DocumentsList({ documents, applicationId, documentTasks }: Docum
             disabled={isGeneratingCoverLetter}
             variant="default"
             size="sm"
+            className="w-full sm:w-auto"
           >
             {isGeneratingCoverLetter ? (
               <>

--- a/components/jobs/job-header.tsx
+++ b/components/jobs/job-header.tsx
@@ -131,12 +131,21 @@ export function JobHeader({ job, application }: JobHeaderProps) {
           <EditJobDialog
             job={job}
             trigger={
-              <Button variant="ghost" size="icon" className="rounded-full">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="rounded-full text-secondary/70 hover:text-accent-teal hover:bg-accent-teal/10 transition-colors"
+              >
                 <Pencil className="w-4 h-4" />
               </Button>
             }
           />
-          <Button variant="ghost" size="icon" onClick={handleDelete} className="rounded-full">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleDelete}
+            className="rounded-full text-error/70 hover:text-error hover:bg-error/10 transition-colors"
+          >
             <Trash2 className="w-4 h-4" />
           </Button>
         </div>

--- a/components/profile/project-editor.tsx
+++ b/components/profile/project-editor.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Plus, Trash2, ExternalLink, Github } from 'lucide-react'
+import { Plus, Trash2, ExternalLink, Github, Pencil, ChevronDown, ChevronUp } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { BulletEditor } from './bullet-editor'
 import type { Project } from '@prisma/client'
@@ -308,7 +308,7 @@ export function ProjectEditor({
                     </div>
                   )}
                 </div>
-                <div className="flex gap-2">
+                <div className="flex gap-1 sm:gap-2">
                   {editingId !== proj.id && (
                     <>
                       <Button
@@ -317,14 +317,25 @@ export function ProjectEditor({
                         onClick={() => startEditing(proj)}
                         className="text-accent-teal"
                       >
-                        Edit
+                        <Pencil className="h-4 w-4 sm:hidden" />
+                        <span className="hidden sm:inline">Edit</span>
                       </Button>
                       <Button
                         variant="ghost"
                         size="sm"
                         onClick={() => setExpandedId(expandedId === proj.id ? null : proj.id)}
                       >
-                        {expandedId === proj.id ? 'Collapse' : 'Expand'}
+                        {expandedId === proj.id ? (
+                          <>
+                            <ChevronUp className="h-4 w-4 sm:hidden" />
+                            <span className="hidden sm:inline">Collapse</span>
+                          </>
+                        ) : (
+                          <>
+                            <ChevronDown className="h-4 w-4 sm:hidden" />
+                            <span className="hidden sm:inline">Expand</span>
+                          </>
+                        )}
                       </Button>
                       <Button
                         variant="ghost"

--- a/components/ui/collapsible.tsx
+++ b/components/ui/collapsible.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import * as CollapsiblePrimitive from '@radix-ui/react-collapsible'
+
+const Collapsible = CollapsiblePrimitive.Root
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,9 +1,9 @@
-"use client"
+'use client'
 
-import * as React from "react"
-import * as SwitchPrimitives from "@radix-ui/react-switch"
+import * as React from 'react'
+import * as SwitchPrimitives from '@radix-ui/react-switch'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-accent-orange data-[state=unchecked]:bg-input',
       className
     )}
     {...props}
@@ -19,7 +19,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+        'pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0'
       )}
     />
   </SwitchPrimitives.Root>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
@@ -5112,6 +5113,36 @@
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-previous": "1.1.1",
         "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -13141,7 +13172,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",


### PR DESCRIPTION
## Summary
- **Dashboard**: Replace mobile tab navigation with collapsible accordion sections per status (chevron, colored bar, label, count badge)
- **Documents**: Stack generate buttons vertically on mobile, side-by-side on desktop
- **Profile skills**: Add "Show all (N)" / "Show less" toggle, collapsing at 10 skills
- **Profile projects**: Use icon-only action buttons (edit, expand, delete) on mobile, text labels on desktop
- **Switch toggle**: Fix checked color from invisible cream (`bg-primary`) to `bg-accent-orange`
- **Job detail header**: Add teal hover to edit icon, red tint + hover to delete icon

Closes #12

## Test plan
- [x] Dashboard at 375px: accordion sections expand/collapse, first section with items auto-expands, correct counts and colored bars
- [x] Job detail > Documents tab at 375px: buttons stack full-width, side-by-side on desktop
- [x] Profile > Skills: only 10 skills shown initially, "Show all" expands, "Show less" collapses
- [x] Profile > Projects at 375px: action buttons are icon-only, text labels on desktop
- [x] Job search toggles (remote, full-time, permanent): orange when active
- [x] Job detail header: edit icon has teal hover, delete icon is red-tinted with red hover