### PR TITLE
feat: cover letter anti-hallucination ground truth engine

### DIFF
--- a/app/api/ai/cover-letter/route.ts
+++ b/app/api/ai/cover-letter/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getCurrentUser } from '@/lib/auth'
 import { createAiTask } from '@/lib/ai-tasks'
+import { prisma } from '@/lib/prisma'
 
 const schema = z.object({
   applicationId: z.string(),
@@ -20,6 +21,26 @@ export async function POST(request: Request) {
 
     const body = await request.json()
     const { applicationId, voice } = schema.parse(body)
+
+    // Verify job fit assessment was completed before generating cover letter
+    const application = await prisma.application.findUnique({
+      where: { id: applicationId, user_id: user.id },
+      select: { fit_score: true },
+    })
+
+    if (!application) {
+      return NextResponse.json({ error: 'Application not found' }, { status: 404 })
+    }
+
+    if (application.fit_score === null) {
+      return NextResponse.json(
+        {
+          error:
+            'Job fit assessment must be completed before generating a cover letter. Please run the fit assessment first.',
+        },
+        { status: 400 }
+      )
+    }
 
     // Map 'auto' to undefined so the engine uses AI-recommended voice
     const effectiveVoice = voice === 'auto' ? undefined : voice

--- a/inngest/functions/cover-letter-generation.ts
+++ b/inngest/functions/cover-letter-generation.ts
@@ -78,6 +78,10 @@ export const coverLetterGenerationFunction = inngest.createFunction(
         throw new Error('User has not confirmed resume')
       }
 
+      if (application.fit_score === null) {
+        throw new Error('Job fit assessment must be completed before generating a cover letter')
+      }
+
       // Step 4: Build structured profile
       const profileData = await step.run('build-profile', async () => {
         return buildStructuredProfile(
@@ -93,7 +97,11 @@ export const coverLetterGenerationFunction = inngest.createFunction(
 
       // Step 5 + 6: Run semantic analysis + generate content via V2 engine
       const engineOutput = await step.run('generate-cover-letter-v2', async () => {
-        return generateCoverLetterV2(userId, profileData, application.Job as any, voice)
+        return generateCoverLetterV2(userId, profileData, application.Job as any, voice, {
+          matching_skills: application.matching_skills,
+          missing_required_skills: application.missing_required_skills,
+          missing_preferred_skills: application.missing_preferred_skills,
+        })
       })
 
       // Step 7: Render PDF via Markdown -> HTML -> Puppeteer

--- a/lib/__tests__/cover-letter-engine.test.ts
+++ b/lib/__tests__/cover-letter-engine.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock OpenAI module (prevents initialization error from resume-generator import chain)
+vi.mock('@/lib/openai', () => ({
+  openai: { chat: { completions: { create: vi.fn() } } },
+  MODELS: { GPT4O: 'gpt-4o-2024-05-13', GPT4O_MINI: 'gpt-4o-mini-2024-07-18' },
+  callOpenAI: vi.fn(),
+  parseOpenAIJson: vi.fn(),
+}))
+
+// Mock Anthropic and prompts
+const { mockCreate } = vi.hoisted(() => ({ mockCreate: vi.fn() }))
+vi.mock('@/lib/anthropic', () => ({
+  anthropic: { messages: { create: mockCreate } },
+  ANTHROPIC_MODELS: { SONNET: 'claude-sonnet-4-5-20250929' },
+  callAnthropic: vi.fn((_userId: string, fn: () => Promise<unknown>) => fn()),
+  parseAnthropicJson: vi.fn((_msg: unknown) => ({})),
+}))
+
+vi.mock('@/lib/prompts', () => ({
+  loadPrompt: vi.fn().mockResolvedValue({
+    content: 'test prompt',
+    metadata: { maxTokens: 2000, temperature: 0.3 },
+  }),
+}))
+
+import { buildSkillGroundTruth } from '@/lib/cover-letter-engine'
+import type { StructuredProfileData } from '@/lib/resume-types'
+
+function createTestProfile(): StructuredProfileData {
+  return {
+    personal: {
+      name: 'Test User',
+      email: 'test@example.com',
+    },
+    education: [],
+    experiences: [
+      {
+        title: 'Software Engineer',
+        company: 'Acme Corp',
+        start_date: '2023-01',
+        is_current: true,
+        bullets: [
+          'Built REST APIs using Flask and Python',
+          'Developed React dashboard for real-time analytics',
+          'Managed PostgreSQL database with 10M+ records',
+        ],
+      },
+      {
+        title: 'Intern',
+        company: 'StartupCo',
+        start_date: '2022-06',
+        end_date: '2022-08',
+        is_current: false,
+        bullets: [
+          'Created Node.js microservices for payment processing',
+          'Wrote unit tests with Jest achieving 90% coverage',
+        ],
+      },
+    ],
+    projects: [
+      {
+        name: 'Klevr',
+        technologies: ['React', 'TypeScript', 'Next.js', 'PostgreSQL'],
+        bullets: [
+          'Built AI-powered job application tracker using TypeScript and React',
+          'Implemented PDF generation with Puppeteer',
+        ],
+      },
+      {
+        name: 'CLI Tool',
+        technologies: ['Python', 'Click'],
+        bullets: ['Developed command-line tool for data processing'],
+      },
+    ],
+    skills: ['React', 'TypeScript', 'Python', 'Flask', 'Node.js', 'PostgreSQL', 'Next.js'],
+  }
+}
+
+describe('buildSkillGroundTruth', () => {
+  it('finds skills in project technologies', () => {
+    const profile = createTestProfile()
+    const result = buildSkillGroundTruth(profile, ['React', 'TypeScript'], [], [])
+
+    const reactEvidence = result.verified_skills.find(v => v.skill === 'React')
+    expect(reactEvidence).toBeDefined()
+    expect(reactEvidence!.found_in.length).toBeGreaterThan(0)
+
+    // React should be found in Klevr project technologies
+    const projectEvidence = reactEvidence!.found_in.find(
+      f => f.type === 'project' && f.name === 'Klevr'
+    )
+    expect(projectEvidence).toBeDefined()
+    expect(projectEvidence!.context).toContain('React')
+  })
+
+  it('finds skills in experience bullet text', () => {
+    const profile = createTestProfile()
+    const result = buildSkillGroundTruth(profile, ['Flask'], [], [])
+
+    const flaskEvidence = result.verified_skills.find(v => v.skill === 'Flask')
+    expect(flaskEvidence).toBeDefined()
+    expect(flaskEvidence!.found_in.length).toBeGreaterThan(0)
+
+    const expEvidence = flaskEvidence!.found_in.find(f => f.type === 'experience')
+    expect(expEvidence).toBeDefined()
+    expect(expEvidence!.context).toContain('Flask')
+  })
+
+  it('returns empty evidence for skills not found in profile content', () => {
+    const profile = createTestProfile()
+    const result = buildSkillGroundTruth(profile, ['Kubernetes'], [], [])
+
+    const k8sEvidence = result.verified_skills.find(v => v.skill === 'Kubernetes')
+    expect(k8sEvidence).toBeDefined()
+    expect(k8sEvidence!.found_in).toHaveLength(0)
+  })
+
+  it('returns empty verified_skills when matching_skills is empty', () => {
+    const profile = createTestProfile()
+    const result = buildSkillGroundTruth(profile, [], ['FastAPI'], ['GraphQL'])
+
+    expect(result.verified_skills).toHaveLength(0)
+    expect(result.missing_required).toEqual(['FastAPI'])
+    expect(result.missing_preferred).toEqual(['GraphQL'])
+  })
+
+  it('includes all_user_skills from profile', () => {
+    const profile = createTestProfile()
+    const result = buildSkillGroundTruth(profile, ['React'], [], [])
+
+    expect(result.all_user_skills).toEqual(profile.skills)
+  })
+
+  it('passes through missing_required and missing_preferred unchanged', () => {
+    const profile = createTestProfile()
+    const result = buildSkillGroundTruth(
+      profile,
+      ['React'],
+      ['FastAPI', 'React Native'],
+      ['GraphQL', 'Redis']
+    )
+
+    expect(result.missing_required).toEqual(['FastAPI', 'React Native'])
+    expect(result.missing_preferred).toEqual(['GraphQL', 'Redis'])
+  })
+
+  it('matches skills case-insensitively in project technologies', () => {
+    const profile = createTestProfile()
+    // Profile has "PostgreSQL" in technologies, matching with different casing
+    const result = buildSkillGroundTruth(profile, ['postgresql'], [], [])
+
+    const pgEvidence = result.verified_skills.find(v => v.skill === 'postgresql')
+    expect(pgEvidence).toBeDefined()
+    expect(pgEvidence!.found_in.length).toBeGreaterThan(0)
+  })
+
+  it('finds evidence across both experiences and projects', () => {
+    const profile = createTestProfile()
+    // "React" appears in both experience bullets and project technologies
+    const result = buildSkillGroundTruth(profile, ['React'], [], [])
+
+    const reactEvidence = result.verified_skills.find(v => v.skill === 'React')
+    expect(reactEvidence).toBeDefined()
+
+    const projectHits = reactEvidence!.found_in.filter(f => f.type === 'project')
+    const expHits = reactEvidence!.found_in.filter(f => f.type === 'experience')
+
+    expect(projectHits.length).toBeGreaterThan(0)
+    expect(expHits.length).toBeGreaterThan(0)
+  })
+})

--- a/lib/__tests__/cover-letter-post-processor.test.ts
+++ b/lib/__tests__/cover-letter-post-processor.test.ts
@@ -435,6 +435,50 @@ describe('postProcessCoverLetter', () => {
     })
   })
 
+  describe('forbidden skills detection', () => {
+    it('warns when a forbidden skill appears in output', () => {
+      const result = postProcessCoverLetter(
+        ['I built REST APIs using FastAPI and deployed to AWS.'],
+        { forbiddenSkills: ['FastAPI'] }
+      )
+      expect(result.fixes).toContain("WARNING: forbidden skill 'FastAPI' detected in paragraph 1")
+    })
+
+    it('detects forbidden skills case-insensitively', () => {
+      const result = postProcessCoverLetter(
+        ['My experience with fastapi includes building microservices.'],
+        { forbiddenSkills: ['FastAPI'] }
+      )
+      expect(result.fixes).toContain("WARNING: forbidden skill 'FastAPI' detected in paragraph 1")
+    })
+
+    it('does not warn when forbidden skills are absent', () => {
+      const result = postProcessCoverLetter(
+        ['I built REST APIs using Flask and deployed to AWS.'],
+        { forbiddenSkills: ['FastAPI', 'React Native'] }
+      )
+      const warnings = result.fixes.filter(f => f.startsWith('WARNING:'))
+      expect(warnings).toHaveLength(0)
+    })
+
+    it('warns for multiple forbidden skills in different paragraphs', () => {
+      const result = postProcessCoverLetter(
+        ['I used FastAPI to build the backend.', 'The mobile app was built with React Native.'],
+        { forbiddenSkills: ['FastAPI', 'React Native'] }
+      )
+      expect(result.fixes).toContain("WARNING: forbidden skill 'FastAPI' detected in paragraph 1")
+      expect(result.fixes).toContain(
+        "WARNING: forbidden skill 'React Native' detected in paragraph 2"
+      )
+    })
+
+    it('does not warn when no forbidden skills provided', () => {
+      const result = postProcessCoverLetter(['I used FastAPI to build services.'])
+      const warnings = result.fixes.filter(f => f.startsWith('WARNING:'))
+      expect(warnings).toHaveLength(0)
+    })
+  })
+
   describe('clean text passes through', () => {
     it('does not modify clean text', () => {
       const clean = 'I built a REST API that served 10K users and reduced latency by 40%.'

--- a/lib/__tests__/resume-to-markdown.test.ts
+++ b/lib/__tests__/resume-to-markdown.test.ts
@@ -333,6 +333,25 @@ describe('generateCoverLetterMarkdown', () => {
     expect(md).not.toContain('john@test.com |')
   })
 
+  it('renders V2 signature with blank line between Sincerely and name', () => {
+    const md = generateCoverLetterMarkdown(
+      {
+        salutation: 'Dear Hiring Team,',
+        paragraphs: ['Body paragraph.'],
+        closing: 'Sincerely,',
+      },
+      { name: 'Jane Doe', email: 'jane@example.com' },
+      { title: 'Software Engineer', company: 'Acme Corp' }
+    )
+
+    // In markdown, "Sincerely," and "Jane Doe" should be separated by a blank line
+    const lines = md.split('\n')
+    const sincerelyIdx = lines.findIndex(l => l === 'Sincerely,')
+    expect(sincerelyIdx).toBeGreaterThan(-1)
+    expect(lines[sincerelyIdx + 1]).toBe('')
+    expect(lines[sincerelyIdx + 2]).toBe('Jane Doe')
+  })
+
   it('accepts V2 structured content with salutation, paragraphs, and closing', () => {
     const md = generateCoverLetterMarkdown(
       {

--- a/lib/cover-letter-engine.ts
+++ b/lib/cover-letter-engine.ts
@@ -5,7 +5,66 @@ import { generateCoverLetterMarkdown } from './markdown/resume-to-markdown'
 import { deepSanitizeEmDashes } from './utils'
 import type { StructuredProfileData } from './resume-types'
 import type { Job } from '@prisma/client'
-import type { CoverLetterVoice, CLSemanticAnalysis, CLEngineOutput } from './cover-letter-types'
+import type {
+  CoverLetterVoice,
+  CoverLetterSkillData,
+  CLSemanticAnalysis,
+  CLEngineOutput,
+  SkillGroundTruth,
+  SkillEvidence,
+} from './cover-letter-types'
+
+// ---- Skill Ground Truth Builder ----
+
+/**
+ * Build a deterministic skill ground truth from profile data and job scoring results.
+ * For each matching skill, finds evidence in experiences and projects.
+ */
+export function buildSkillGroundTruth(
+  profileData: StructuredProfileData,
+  matchingSkills: string[],
+  missingRequired: string[],
+  missingPreferred: string[]
+): SkillGroundTruth {
+  const verifiedSkills: SkillEvidence[] = matchingSkills.map(skill => {
+    const found_in: SkillEvidence['found_in'] = []
+    const skillLower = skill.toLowerCase()
+
+    // Search project technologies and bullets
+    for (const proj of profileData.projects) {
+      const inTech = proj.technologies.some(t => t.toLowerCase() === skillLower)
+      const matchingBullets = proj.bullets.filter(b => b.toLowerCase().includes(skillLower))
+
+      if (inTech || matchingBullets.length > 0) {
+        const context = inTech
+          ? `Technologies: ${proj.technologies.join(', ')}`
+          : matchingBullets[0]
+        found_in.push({ type: 'project', name: proj.name, context })
+      }
+    }
+
+    // Search experience bullets
+    for (const exp of profileData.experiences) {
+      const matchingBullets = exp.bullets.filter(b => b.toLowerCase().includes(skillLower))
+      if (matchingBullets.length > 0) {
+        found_in.push({
+          type: 'experience',
+          name: `${exp.title} at ${exp.company}`,
+          context: matchingBullets[0],
+        })
+      }
+    }
+
+    return { skill, found_in }
+  })
+
+  return {
+    verified_skills: verifiedSkills,
+    missing_required: missingRequired,
+    missing_preferred: missingPreferred,
+    all_user_skills: profileData.skills,
+  }
+}
 
 // ---- Semantic Analysis ----
 
@@ -16,11 +75,12 @@ import type { CoverLetterVoice, CLSemanticAnalysis, CLEngineOutput } from './cov
 async function runCLSemanticAnalysis(
   userId: string,
   profileData: StructuredProfileData,
-  job: Job
+  job: Job,
+  groundTruth?: SkillGroundTruth
 ): Promise<CLSemanticAnalysis> {
   const { content: prompt, metadata } = await loadPrompt('cover-letter', 'semantic-analysis-v1')
 
-  const input = {
+  const input: Record<string, unknown> = {
     job: {
       title: job.title,
       company: job.company,
@@ -48,6 +108,18 @@ async function runCLSemanticAnalysis(
         gpa: edu.gpa,
       })),
     },
+  }
+
+  if (groundTruth) {
+    input.skill_boundaries = {
+      verified_skills: groundTruth.verified_skills.map(vs => ({
+        skill: vs.skill,
+        evidence: vs.found_in.map(f => f.context).slice(0, 3),
+      })),
+      missing_required: groundTruth.missing_required,
+      missing_preferred: groundTruth.missing_preferred,
+      all_user_skills: groundTruth.all_user_skills,
+    }
   }
 
   const message = await callAnthropic(
@@ -86,7 +158,8 @@ async function generateCLContent(
   profileData: StructuredProfileData,
   job: Job,
   analysis: CLSemanticAnalysis,
-  voice: CoverLetterVoice
+  voice: CoverLetterVoice,
+  forbiddenSkills?: string[]
 ): Promise<CLGeneratedContent> {
   const { content: prompt, metadata } = await loadPrompt('cover-letter', 'generate-v2')
 
@@ -117,7 +190,7 @@ async function generateCLContent(
     })
     .filter(Boolean)
 
-  const input = {
+  const input: Record<string, unknown> = {
     user_name: profileData.personal.name,
     job: {
       title: job.title,
@@ -135,6 +208,13 @@ async function generateCLContent(
       skills_to_weave: analysis.skills_to_weave,
     },
     education_context: analysis.education_to_feature ?? null,
+  }
+
+  if (forbiddenSkills && forbiddenSkills.length > 0) {
+    input.skill_boundaries = {
+      forbidden_skills: forbiddenSkills,
+      adjacency_map: analysis.adjacency_map ?? [],
+    }
   }
 
   const message = await callAnthropic(
@@ -173,21 +253,44 @@ export async function generateCoverLetterV2(
   userId: string,
   profileData: StructuredProfileData,
   job: Job,
-  voice?: CoverLetterVoice
+  voice?: CoverLetterVoice,
+  skillData?: CoverLetterSkillData
 ): Promise<CLEngineOutput> {
+  // Step 0: Build skill ground truth if scoring data is available
+  const groundTruth = skillData
+    ? buildSkillGroundTruth(
+        profileData,
+        skillData.matching_skills,
+        skillData.missing_required_skills,
+        skillData.missing_preferred_skills
+      )
+    : undefined
+
+  const forbiddenSkills = groundTruth
+    ? [...groundTruth.missing_required, ...groundTruth.missing_preferred]
+    : undefined
+
   // Step 1: Semantic analysis
-  const analysis = await runCLSemanticAnalysis(userId, profileData, job)
+  const analysis = await runCLSemanticAnalysis(userId, profileData, job, groundTruth)
 
   // Use recommended voice from analysis if no explicit override provided
   const recommendedVoice = analysis.recommended_voice || 'professional'
   const effectiveVoice = voice ?? recommendedVoice
 
   // Step 2: Generate content
-  const rawContent = await generateCLContent(userId, profileData, job, analysis, effectiveVoice)
+  const rawContent = await generateCLContent(
+    userId,
+    profileData,
+    job,
+    analysis,
+    effectiveVoice,
+    forbiddenSkills
+  )
 
-  // Step 3: Post-process (with metric context for vague qualifier detection)
+  // Step 3: Post-process (with metric context and forbidden skills detection)
   const { paragraphs: processedParagraphs, fixes } = postProcessCoverLetter(rawContent.paragraphs, {
     metricsToFeature: analysis.metrics_to_feature,
+    forbiddenSkills,
   })
 
   const content = {

--- a/lib/cover-letter-post-processor.ts
+++ b/lib/cover-letter-post-processor.ts
@@ -636,10 +636,11 @@ function enforceRhythmCap(paragraphs: string[], fixes: string[]): string[] {
  */
 export function postProcessCoverLetter(
   paragraphs: string[],
-  options?: { metricsToFeature?: string[] }
+  options?: { metricsToFeature?: string[]; forbiddenSkills?: string[] }
 ): PostProcessorResult {
   const fixes: string[] = []
   const metricsToFeature = options?.metricsToFeature ?? []
+  const forbiddenSkills = options?.forbiddenSkills ?? []
 
   const processed = paragraphs.map(paragraph => {
     let text = paragraph
@@ -665,6 +666,18 @@ export function postProcessCoverLetter(
 
   // Global rhythm cap: enforce 30% I/My sentence-start ceiling across all paragraphs
   const rhythmProcessed = enforceRhythmCap(processed, fixes)
+
+  // Forbidden skills detection: warn if any forbidden skill appears in output
+  if (forbiddenSkills.length > 0) {
+    for (let i = 0; i < rhythmProcessed.length; i++) {
+      const paraLower = rhythmProcessed[i].toLowerCase()
+      for (const skill of forbiddenSkills) {
+        if (paraLower.includes(skill.toLowerCase())) {
+          fixes.push(`WARNING: forbidden skill '${skill}' detected in paragraph ${i + 1}`)
+        }
+      }
+    }
+  }
 
   // Deduplicate fixes
   const uniqueFixes = [...new Set(fixes)]

--- a/lib/cover-letter-types.ts
+++ b/lib/cover-letter-types.ts
@@ -48,6 +48,30 @@ export const VOICE_SELECTION_DESCRIPTIONS: Record<CoverLetterVoiceSelection, str
   ...VOICE_DESCRIPTIONS,
 }
 
+// ---- Skill Ground Truth (anti-hallucination) ----
+
+export interface SkillEvidence {
+  skill: string
+  found_in: Array<{
+    type: 'experience' | 'project'
+    name: string
+    context: string
+  }>
+}
+
+export interface SkillGroundTruth {
+  verified_skills: SkillEvidence[]
+  missing_required: string[]
+  missing_preferred: string[]
+  all_user_skills: string[]
+}
+
+export interface CoverLetterSkillData {
+  matching_skills: string[]
+  missing_required_skills: string[]
+  missing_preferred_skills: string[]
+}
+
 export interface CLSemanticAnalysis {
   primary_pain_point: string
   role_intent: string
@@ -71,6 +95,11 @@ export interface CLSemanticAnalysis {
   metrics_to_feature: string[]
   skills_to_weave: string[]
   recommended_voice: CoverLetterVoice
+  adjacency_map?: Array<{
+    missing_skill: string
+    adjacent_user_skill: string
+    reframe_angle: string
+  }>
   education_to_feature?: {
     credential: string
     graduation_date: string

--- a/lib/markdown/resume-to-markdown.ts
+++ b/lib/markdown/resume-to-markdown.ts
@@ -257,6 +257,7 @@ export function generateCoverLetterMarkdown(
     }
 
     lines.push('Sincerely,')
+    lines.push('')
     lines.push(userInfo.name)
   }
 

--- a/prompts/cover-letter/generate-v2.md
+++ b/prompts/cover-letter/generate-v2.md
@@ -52,6 +52,16 @@ Generate a compelling, narrative cover letter that bridges the user's experience
     "graduation_date": "May 2026",
     "gpa": "3.8",
     "relevance_note": "Why this credential matters"
+  },
+  "skill_boundaries": {
+    "forbidden_skills": ["FastAPI", "React Native", "GraphQL"],
+    "adjacency_map": [
+      {
+        "missing_skill": "FastAPI",
+        "adjacent_user_skill": "Flask",
+        "reframe_angle": "Python API development with Flask"
+      }
+    ]
   }
 }
 ```
@@ -203,6 +213,15 @@ If education_context is provided and not null:
 
 If education_context is null, do not mention education at all.
 
+## Skill Boundary Rules
+
+When `skill_boundaries` is present in the input:
+
+1. The `forbidden_skills` list contains skills the job requires but the user does NOT have. You MUST NEVER claim experience with, mention proficiency in, or imply familiarity with any forbidden skill.
+2. When the role's competency area overlaps with a forbidden skill, use the `adjacency_map` to reframe: lean into the user's actual adjacent skill instead. Example: if "FastAPI" is forbidden but "Flask" is adjacent, write about Python API experience using Flask - never mention FastAPI.
+3. You may include AT MOST ONE forward-looking sentence per letter acknowledging interest in expanding into a gap area, but ONLY if the `adjacency_map` provides a strong adjacent skill to anchor it. Example: "Building on my Flask API experience, I am eager to deepen my work with Python web frameworks."
+4. If no adjacency exists for a missing skill, simply omit that competency area from the narrative entirely. Silence is better than fabrication.
+
 ## NEVER Rules
 
 These are absolute constraints. The post-processor will catch violations, but prevent them in the first place:
@@ -221,6 +240,7 @@ These are absolute constraints. The post-processor will catch violations, but pr
 12. **NEVER use mantra-style three-part slogans.** Do not write "Analyze, Automate, Accelerate" or "I build, I ship, I lead" or any triadic rhetorical structure.
 13. **NEVER open with a cliche setup** like "In today's fast-paced world" or "In today's competitive market." Start with a concrete value statement tied to the company's specific need.
 14. **NEVER summarize the job description** back to the reader. They already know the role. Focus on YOUR story and how it connects to THEIR need.
+15. **NEVER mention forbidden skills** - when `skill_boundaries` is present, do not write the name of any skill in `skill_boundaries.forbidden_skills`. Do not claim experience with them, do not reference projects using them, do not imply familiarity. If you would naturally mention a forbidden skill, use the adjacent skill from the adjacency_map instead, or omit entirely.
 
 ## Length Target
 

--- a/prompts/cover-letter/semantic-analysis-v1.md
+++ b/prompts/cover-letter/semantic-analysis-v1.md
@@ -37,6 +37,14 @@ Analyze the job description to identify the company's **primary pain point** and
       }
     ],
     "skills": ["string"],
+    "skill_boundaries": {
+      "verified_skills": [
+        { "skill": "React", "evidence": ["Built real-time dashboard using React..."] }
+      ],
+      "missing_required": ["FastAPI", "React Native"],
+      "missing_preferred": ["GraphQL"],
+      "all_user_skills": ["React", "TypeScript", "Node.js", "Python", "Flask"]
+    },
     "education": [
       {
         "school": "string",
@@ -85,6 +93,13 @@ Return ONLY valid JSON matching this structure:
     "Exact metric strings from user's bullets to weave into narrative, e.g. '40% latency reduction'"
   ],
   "skills_to_weave": ["Skills from the user's profile that map to JD requirements"],
+  "adjacency_map": [
+    {
+      "missing_skill": "FastAPI",
+      "adjacent_user_skill": "Flask",
+      "reframe_angle": "Python API development with Flask"
+    }
+  ],
   "recommended_voice": "casual",
   "education_to_feature": {
     "credential": "B.S. in Computer Science, University of X",
@@ -166,6 +181,16 @@ If no education data exists in the profile, always omit this field entirely.
 
 If the conditions for inclusion are not met, omit the `education_to_feature` field from the output.
 
+### 9. Skill Boundary Enforcement
+
+When `skill_boundaries` is present in the input:
+
+- `skills_to_weave` MUST only contain skills from `verified_skills` or `all_user_skills` - never include a skill from `missing_required` or `missing_preferred`
+- Bridge angles MUST NOT claim the user has experience with any skill in `missing_required` or `missing_preferred`
+- For each skill in `missing_required`, identify the user's closest related skill from `all_user_skills` and output it in `adjacency_map`
+- If no adjacent skill exists for a missing skill, omit it from the `adjacency_map`
+- Only include `adjacency_map` when `skill_boundaries` is present and there are missing skills with plausible adjacent user skills
+
 ## Critical Rules
 
 1. **No hallucination** - only reference experiences, projects, and skills from the input
@@ -173,5 +198,6 @@ If the conditions for inclusion are not met, omit the `education_to_feature` fie
 3. **Max 2 experiences + 1 project** - cover letters are focused, not exhaustive
 4. **Metrics must be exact** - copy metric strings verbatim from bullets
 5. **Skills must exist in profile** - never suggest skills the user doesn't have
-6. **JSON only** - return ONLY valid JSON, no markdown or explanations
-7. **No em dashes** - never use em dashes or en dashes in any text field. Use a regular hyphen ( - ) instead
+6. **Skills must respect boundaries** - when `skill_boundaries` is present, `skills_to_weave` can ONLY include skills from `skill_boundaries.verified_skills` or `skill_boundaries.all_user_skills`. NEVER suggest or weave a skill from `missing_required` or `missing_preferred`
+7. **JSON only** - return ONLY valid JSON, no markdown or explanations
+8. **No em dashes** - never use em dashes or en dashes in any text field. Use a regular hyphen ( - ) instead


### PR DESCRIPTION
## Summary

- Adds a skill ground truth engine that builds verified skill evidence from the user's profile and feeds explicit skill boundaries (verified, missing required, missing preferred) into the cover letter semantic analysis and generation prompts
- Prompts now receive forbidden skill lists with adjacency mappings so Claude reframes around actual user skills instead of fabricating experience with missing ones
- Post-processor scans for forbidden skill mentions as a safety net
- Requires job fit scoring before cover letter generation to guarantee skill gap data exists
- Fixes V2 cover letter signature rendering "Sincerely," and name on one line

Closes #13

## Test plan

- [x] `npm run typecheck` passes
- [x] All 276 tests pass (`npm test`)
- [ ] Generate a cover letter for a job requiring skills the user lacks - verify the letter does not mention those skills
- [ ] Generate a cover letter for an application without a fit score - verify 400 error
- [ ] Check PDF output for correct signature line break