### PR TITLE
fix: sanitize document display names and set download filenames

### DIFF
--- a/app/api/documents/[id]/download/route.ts
+++ b/app/api/documents/[id]/download/route.ts
@@ -31,6 +31,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
       },
       select: {
         storage_url: true,
+        display_name: true,
       },
     })
 
@@ -39,7 +40,8 @@ export async function GET(_request: Request, { params }: RouteParams) {
     }
 
     // Generate presigned URL (expires in 15 minutes)
-    const url = await generateDownloadUrl(document.storage_url, 900)
+    const downloadName = document.display_name ? `${document.display_name}.pdf` : undefined
+    const url = await generateDownloadUrl(document.storage_url, 900, downloadName)
 
     return NextResponse.json({
       url,

--- a/inngest/functions/cover-letter-generation.ts
+++ b/inngest/functions/cover-letter-generation.ts
@@ -4,6 +4,7 @@ import { generateCoverLetterV2 } from '@/lib/cover-letter-engine'
 import { buildStructuredProfile } from '@/lib/resume-generator'
 import { renderCoverLetterPDFv2 } from '@/lib/pdf/renderer'
 import { uploadBuffer, generateDocumentKey } from '@/lib/s3'
+import { sanitizeFileName } from '@/lib/utils'
 import { incrementUsage, checkUsageLimit } from '@/lib/usage'
 import { logAiTaskComplete } from '@/lib/activity-log'
 import { DocumentType, AiTaskStatus } from '@prisma/client'
@@ -119,11 +120,10 @@ export const coverLetterGenerationFunction = inngest.createFunction(
 
       // Step 9: Save document record with rich structured_data
       const document = await step.run('save-document', async () => {
-        const now = new Date()
-        const month = now.toLocaleString('en-US', { month: 'short' })
-        const year = now.getFullYear()
         const userName = application.User.Profile!.full_name || 'Cover Letter'
-        const displayName = `${userName} ${application.Job.title} ${application.Job.company} Cover Letter ${month} ${year}`
+        const displayName = sanitizeFileName(
+          `${userName} ${application.Job.title} ${application.Job.company} Cover Letter`
+        )
 
         return prisma.generatedDocument.create({
           data: {

--- a/inngest/functions/resume-generation.ts
+++ b/inngest/functions/resume-generation.ts
@@ -6,6 +6,7 @@ import { analyzeJobDescription } from '@/lib/semantic-analyzer'
 import { markdownToHtml } from '@/lib/pdf/markdown-to-html'
 import { htmlToPdf } from '@/lib/pdf/html-to-pdf'
 import { uploadBuffer, generateDocumentKey } from '@/lib/s3'
+import { sanitizeFileName } from '@/lib/utils'
 import { incrementUsage, checkUsageLimit } from '@/lib/usage'
 import { logAiTaskComplete } from '@/lib/activity-log'
 import { DocumentType, AiTaskStatus } from '@prisma/client'
@@ -146,11 +147,8 @@ export const resumeGenerationFunction = inngest.createFunction(
 
       // Step 9: Save document record
       const document = await step.run('save-document', async () => {
-        const now = new Date()
-        const month = now.toLocaleString('en-US', { month: 'short' })
-        const year = now.getFullYear()
         const userName = profile.full_name || 'Resume'
-        const displayName = `${userName} ${job.title} ${job.company} ${month} ${year}`
+        const displayName = sanitizeFileName(`${userName} ${job.title} ${job.company}`)
 
         return prisma.generatedDocument.create({
           data: {

--- a/lib/__tests__/s3.test.ts
+++ b/lib/__tests__/s3.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockGetSignedUrl } from '@/__tests__/helpers'
+
+vi.mock('@aws-sdk/client-s3', () => {
+  class MockS3Client {
+    send = vi.fn()
+  }
+  return {
+    S3Client: MockS3Client,
+    PutObjectCommand: vi.fn(),
+    GetObjectCommand: vi.fn(),
+    DeleteObjectCommand: vi.fn(),
+  }
+})
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: mockGetSignedUrl,
+}))
+
+import { GetObjectCommand } from '@aws-sdk/client-s3'
+import { generateDownloadUrl } from '@/lib/s3'
+
+describe('generateDownloadUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('sets disposition to "attachment" when no filename provided', async () => {
+    await generateDownloadUrl('documents/abc/resume-123.pdf')
+
+    expect(GetObjectCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ResponseContentDisposition: 'attachment',
+      })
+    )
+  })
+
+  it('includes filename in Content-Disposition when provided', async () => {
+    await generateDownloadUrl('documents/abc/resume-123.pdf', 900, 'Tyler Jarvis Resume.pdf')
+
+    expect(GetObjectCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ResponseContentDisposition: 'attachment; filename="Tyler Jarvis Resume.pdf"',
+      })
+    )
+  })
+
+  it('encodes special characters in filename', async () => {
+    await generateDownloadUrl('key', 900, 'file%name.pdf')
+
+    expect(GetObjectCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ResponseContentDisposition: 'attachment; filename="file%25name.pdf"',
+      })
+    )
+  })
+})

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import {
   formatDate,
   getCurrentMonth,
   truncate,
+  sanitizeFileName,
   sanitizeEmDashes,
   deepSanitizeEmDashes,
 } from '@/lib/utils'
@@ -83,6 +84,46 @@ describe('truncate', () => {
 
   it('handles empty string', () => {
     expect(truncate('', 10)).toBe('')
+  })
+})
+
+describe('sanitizeFileName', () => {
+  it('removes filesystem-unsafe characters', () => {
+    expect(sanitizeFileName('file/name:test*doc')).toBe('filenametestdoc')
+  })
+
+  it('removes parentheses', () => {
+    expect(sanitizeFileName('Company (Inc)')).toBe('Company Inc')
+  })
+
+  it('removes quotes and angle brackets', () => {
+    expect(sanitizeFileName('a "b" <c>')).toBe('a b c')
+  })
+
+  it('removes pipe and backslash', () => {
+    expect(sanitizeFileName('a|b\\c')).toBe('abc')
+  })
+
+  it('collapses multiple spaces into one', () => {
+    expect(sanitizeFileName('Tyler   Jarvis   Resume')).toBe('Tyler Jarvis Resume')
+  })
+
+  it('trims leading and trailing whitespace', () => {
+    expect(sanitizeFileName('  hello  ')).toBe('hello')
+  })
+
+  it('returns "Document" for empty string', () => {
+    expect(sanitizeFileName('')).toBe('Document')
+  })
+
+  it('returns "Document" when all characters are stripped', () => {
+    expect(sanitizeFileName('/:*?"<>|()')).toBe('Document')
+  })
+
+  it('handles a realistic display name', () => {
+    expect(sanitizeFileName('Tyler Jarvis Software Engineer WITS')).toBe(
+      'Tyler Jarvis Software Engineer WITS'
+    )
   })
 })
 

--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -54,12 +54,19 @@ export async function generateUploadUrl(
  */
 export async function generateDownloadUrl(
   key: string,
-  expiresIn: number = 900 // 15 minutes
+  expiresIn: number = 900, // 15 minutes
+  filename?: string
 ): Promise<string> {
+  let disposition = 'attachment'
+  if (filename) {
+    const encoded = encodeURIComponent(filename).replace(/%20/g, ' ')
+    disposition = `attachment; filename="${encoded}"`
+  }
+
   const command = new GetObjectCommand({
     Bucket: S3_BUCKET,
     Key: key,
-    ResponseContentDisposition: 'attachment',
+    ResponseContentDisposition: disposition,
   })
 
   return getSignedUrl(s3Client, command, { expiresIn })

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -45,6 +45,19 @@ export function sanitizeEmDashes(text: string): string {
 }
 
 /**
+ * Sanitize a string for use as a filename.
+ * Removes filesystem-unsafe characters and collapses whitespace.
+ */
+export function sanitizeFileName(name: string): string {
+  return (
+    name
+      .replace(/[/\\:*?"<>|()]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim() || 'Document'
+  )
+}
+
+/**
  * Recursively sanitize em/en dashes in all string values of a nested structure
  */
 export function deepSanitizeEmDashes<T>(value: T): T {


### PR DESCRIPTION
## Summary
- Remove date suffix (e.g., `Mar 2026`) from generated resume and cover letter display names
- Add `sanitizeFileName` utility to strip filesystem-unsafe characters (`/ \ : * ? " < > | ( )`)
- Update `generateDownloadUrl` to include the display name in the `Content-Disposition` header so browsers save files with human-readable names instead of S3 object keys (e.g., `resume-1772660219814.pdf`)
- Pass `display_name` through the download API route to the presigned URL generator

Closes #18

## Test plan
- [x] `npm run typecheck` passes with no errors
- [x] All 321 existing tests pass
- [x] New `sanitizeFileName` tests cover unsafe chars, parentheses, whitespace collapse, empty strings, and realistic names (9 tests)
- [x] New `generateDownloadUrl` tests verify Content-Disposition header with and without filename (3 tests)
- [x] Manual: generate a resume, verify display name has no date suffix
- [x] Manual: download a generated document, verify browser saves with human-readable filename